### PR TITLE
Remove plugin wrapper.

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -39,9 +39,9 @@ type AttachCommand struct {
 
 // NewAttachCommand creates a new AttachCommand.
 func NewAttachCommand() cmd.Command {
-	return WrapPlugin(&AttachCommand{
+	return &AttachCommand{
 		CharmResolver: NewCharmStoreResolver(),
-	})
+	}
 }
 
 // SetFlags implements Command.SetFlags.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -78,42 +77,4 @@ func (c *baseCommand) SetFlags(f *gnuflag.FlagSet) {
 		c.ServiceURL = defaultServiceURL()
 	}
 	f.StringVar(&c.ServiceURL, "url", c.ServiceURL, "host and port of the plans services")
-}
-
-type commandWithDescription interface {
-	cmd.Command
-	Description() string
-}
-
-// WrapPlugin returns a wrapped plugin command.
-func WrapPlugin(cmd commandWithDescription) cmd.Command {
-	return &pluginWrapper{commandWithDescription: cmd}
-}
-
-type pluginWrapper struct {
-	commandWithDescription
-	Description bool
-}
-
-// SetFlags implements Command.SetFlags.
-func (c *pluginWrapper) SetFlags(f *gnuflag.FlagSet) {
-	c.commandWithDescription.SetFlags(f)
-	f.BoolVar(&c.Description, "description", false, "returns command description")
-}
-
-// Init implements Command.Init.
-func (c *pluginWrapper) Init(args []string) error {
-	if c.Description {
-		return nil
-	}
-	return c.commandWithDescription.Init(args)
-}
-
-// Run implements Command.Run.
-func (c *pluginWrapper) Run(ctx *cmd.Context) error {
-	if c.Description {
-		fmt.Fprint(ctx.Stdout, c.commandWithDescription.Description())
-		return nil
-	}
-	return c.commandWithDescription.Run(ctx)
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -32,7 +32,7 @@ var (
 
 // NewPushCommand returns a new PushCommand.
 func NewPushCommand() cmd.Command {
-	return WrapPlugin(&PushCommand{})
+	return &PushCommand{}
 }
 
 // PushCommand uploads a new plan to the plans service

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -29,7 +29,7 @@ type ReleaseCommand struct {
 
 // NewReleaseCommand creates a new ReleaseCommand.
 func NewReleaseCommand() cmd.Command {
-	return WrapPlugin(&ReleaseCommand{})
+	return &ReleaseCommand{}
 }
 
 // SetFlags implements Command.SetFlags.

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -17,10 +17,10 @@ const resumePlanPurpose = "resumes plan for specified charms"
 
 // NewResumeCommand creates a new resumeCommand.
 func NewResumeCommand() cmd.Command {
-	return WrapPlugin(&suspendResumeCommand{
+	return &suspendResumeCommand{
 		op:      resumeOp,
 		name:    "resume-plan",
 		purpose: resumePlanPurpose,
 		doc:     resumePlanDoc,
-	})
+	}
 }

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -36,7 +36,7 @@ type ShowRevisionsCommand struct {
 
 // NewShowRevisionsCommand creates a new ShowRevisionsCommand.
 func NewShowRevisionsCommand() cmd.Command {
-	return WrapPlugin(&ShowRevisionsCommand{})
+	return &ShowRevisionsCommand{}
 }
 
 // SetFlags implements Command.SetFlags.

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -40,7 +40,7 @@ type ShowCommand struct {
 
 // NewShowCommand creates a new ShowCommand.
 func NewShowCommand() cmd.Command {
-	return WrapPlugin(&ShowCommand{})
+	return &ShowCommand{}
 }
 
 // SetFlags implements Command.SetFlags.

--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -20,12 +20,12 @@ const suspendPlanPurpose = "suspends plan for specified charms"
 // NewSuspendCommand creates a new command that can
 // be used to suspend plans.
 func NewSuspendCommand() cmd.Command {
-	return WrapPlugin(&suspendResumeCommand{
+	return &suspendResumeCommand{
 		op:      suspendOp,
 		name:    "suspend-plan",
 		purpose: suspendPlanPurpose,
 		doc:     suspendPlanDoc,
-	})
+	}
 }
 
 type operation string


### PR DESCRIPTION
Remove the plugin wrapper from command constructors, as these commands are going to be compiled into charmstore-client. See juju/charmstore-client#149.