### PR TITLE
cmd/release: Give the user advice on what action to take

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -119,7 +119,7 @@ func (c *client) Release(planID string) (*wireformat.Plan, error) {
 	response, err := c.client.Do(req)
 	if err != nil {
 		if strings.Contains(err.Error(), "refused discharge") {
-			return nil, errors.Errorf(`unauthorized to release the plan: only members of the administrator group are allowed to release plans`)
+			return nil, errors.Annotate(err, `release-plan is currently disabled for public use. Please ask in #juju-partners on freenode or email juju@lists.ubuntu.com`)
 		}
 		return nil, errors.Annotate(err, "failed to release the plan")
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -128,7 +128,7 @@ func (s *clientIntegrationSuite) TestReleaseUnauthorized(c *gc.C) {
 	s.httpClient.SetErrors(errors.New("refused discharge: unauthorized"))
 
 	_, err := s.planClient.Release("testisv/default/1")
-	c.Assert(err, gc.ErrorMatches, `unauthorized to release the plan: only members of the administrator group are allowed to release plans`)
+	c.Assert(err, gc.ErrorMatches, `release-plan is currently disabled for public use. Please ask in #juju-partners on freenode or email juju@lists.ubuntu.com: refused discharge: unauthorized`)
 }
 
 func (s *clientIntegrationSuite) TestSuspend(c *gc.C) {

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -56,6 +56,7 @@ effective from 01 Jan 16 01:00 UTC
 	}
 
 	for i, t := range tests {
+		s.mockAPI.ResetCalls()
 		c.Logf("Running test %d %s", i, t.about)
 		ctx, err := cmdtesting.RunCommand(c, cmd.NewReleaseCommand(), t.args...)
 		if t.err != "" {


### PR DESCRIPTION
Much more `sensible` approach. If the response looks like a permissions problem we suggest action to the user